### PR TITLE
Exclude Gemfile.lock

### DIFF
--- a/languages.yml
+++ b/languages.yml
@@ -4451,7 +4451,8 @@ Ruby:
   - Deliverfile
   - Fastfile
   - Gemfile
-  - Gemfile.lock
+  # Gemfile.lock is not valid ruby
+  # - Gemfile.lock
   - Guardfile
   - Jarfile
   - Mavenfile

--- a/lingo.cabal
+++ b/lingo.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 build-type:          Custom
 name:                lingo
-version:             0.1.0.1
+version:             0.2.0.0
 synopsis:            File extension based programming language detection
 description:         Lingo uses github/linguist's language registry to enable fast detection of a file path's programming langauge based on extension or filename.
 homepage:            https://github.com/tclem/lingo-haskell

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,6 +12,9 @@ main = hspec $ do
     it "can detect Ruby by filename" $
       languageName <$> languageForPath "Rakefile" `shouldBe` Just "Ruby"
 
+    it "Gemfile.lock is not Ruby" $
+      languageName <$> languageForPath "Gemfile.lock" `shouldBe` Nothing
+
     it "returns Nothing for unknown files" $
       languageName <$> languageForPath "noideawhatthisis" `shouldBe` Nothing
 
@@ -22,4 +25,4 @@ main = hspec $ do
     it "parsed languages.yml" $ do
       length languages `shouldBe` 519
       length languagesByExtension `shouldBe` 1117
-      length languagesByFileName `shouldBe` 235
+      length languagesByFileName `shouldBe` 234


### PR DESCRIPTION
`Gemfile.lock` isn't valid ruby code and since lingo is used to select parsers for https://github.com/github/semantic, this is causing the system to try and parse lock files as ruby. Removing with a comment as the languages.yml file comes from linguist so that in future updates of that file we know what's going on.

cc @maxbrunsfeld