### PR TITLE
Fix ambiguity

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,15 @@
+# 0.3.0.0
+
+`languageForPath` is now `languagesForPath`, which returns multiple results in cases of ambiguity.
+
+# 0.2.0.0
+
+Fix bug where `Gemfile.lock` files were being recognized as Ruby.
+
+# 0.1.0.1
+
+Adds documentation.
+
+# 0.1.0.0
+
+Initial release.

--- a/lingo.cabal
+++ b/lingo.cabal
@@ -1,7 +1,7 @@
 cabal-version:       2.4
 build-type:          Custom
 name:                lingo
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            File extension based programming language detection
 description:         Lingo uses github/linguist's language registry to enable fast detection of a file path's programming langauge based on extension or filename.
 homepage:            https://github.com/tclem/lingo-haskell
@@ -12,6 +12,7 @@ maintainer:          timothy.clem@gmail.com
 category:            Data
 extra-source-files:  README.md
                    , languages.yml
+                   , ChangeLog.md
 
 custom-setup
   setup-depends:       Cabal

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,7 +1,8 @@
 module Main where
 
-import Test.Hspec
 import Data.Languages
+import Data.List (sort)
+import Test.Hspec
 
 main :: IO ()
 main = hspec $ do
@@ -11,6 +12,9 @@ main = hspec $ do
 
     it "can detect Ruby by filename" $
       languageName <$> languagesForPath "Rakefile" `shouldBe` ["Ruby"]
+
+    it "returns all languages that a PHP file could be" $
+      sort (languageName <$> languagesForPath "test.php") `shouldBe` ["Hack", "PHP"]
 
     it "Gemfile.lock is not Ruby" $
       languageName <$> languagesForPath "Gemfile.lock" `shouldBe` []

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,19 +7,19 @@ main :: IO ()
 main = hspec $ do
   describe "detect language for path" $ do
     it "can detect Ruby by file extension" $
-      languageName <$> languageForPath "test.rb" `shouldBe` Just "Ruby"
+      languageName <$> languagesForPath "test.rb" `shouldBe` ["Ruby"]
 
     it "can detect Ruby by filename" $
-      languageName <$> languageForPath "Rakefile" `shouldBe` Just "Ruby"
+      languageName <$> languagesForPath "Rakefile" `shouldBe` ["Ruby"]
 
     it "Gemfile.lock is not Ruby" $
-      languageName <$> languageForPath "Gemfile.lock" `shouldBe` Nothing
+      languageName <$> languagesForPath "Gemfile.lock" `shouldBe` []
 
     it "returns Nothing for unknown files" $
-      languageName <$> languageForPath "noideawhatthisis" `shouldBe` Nothing
+      languageName <$> languagesForPath "noideawhatthisis" `shouldBe` []
 
     it "returns Nothing for unknown extensions" $
-      languageName <$> languageForPath ".noideawhatthisis" `shouldBe` Nothing
+      languageName <$> languagesForPath ".noideawhatthisis" `shouldBe` []
 
   describe "languages" $
     it "parsed languages.yml" $ do


### PR DESCRIPTION
`languageForPath` is now `languagesForPath`, which returns multiple results in cases of ambiguity.