### PR TITLE
Use Text instead of LanguageKey for the name.

### DIFF
--- a/src/Data/Languages/Templates.hs
+++ b/src/Data/Languages/Templates.hs
@@ -30,7 +30,7 @@ type LanguageKey = Text
 -- | Identifies a programming language.
 data Language = Language
   { languageId :: Integer,
-    languageName :: LanguageKey,
+    languageName :: Text,
     languageExtensions :: [Text],
     languageFileNames :: [Text]
   }


### PR DESCRIPTION
ghc 8.10 has changed the behaviour of `DeriveLift` and this appears to interfere with us deriving it in this instance.